### PR TITLE
Use tox to run tests in various environments.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+branch = True
+omit = confmodel/_version.py
+
+[report]
+exclude_lines =
+    # pragma: no cover
+    raise AssertionError
+    class \w+\(Interface\):

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
-python:
-  - "2.7"
 install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
   - pip install coveralls
 script:
-  - py.test --cov confmodel confmodel
-  - coverage report -m
+  # Run tests in various environments using tox.
+  - tox
+  # Run tests again with coverage.
+  - py.test --cov-report=term-missing --cov=confmodel confmodel
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+env:
+  - PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+flake8
 pytest
 pytest-cov
-flake8
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, pypy
+
+[testenv]
+deps = pytest
+commands = py.test {envsitepackagesdir}/confmodel


### PR DESCRIPTION
Tests run in under a second, so no need to run multiple build jobs for different Python versions.
